### PR TITLE
Support WSL and custom node command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,16 @@ By default, node is run from the Windows Subsystem for Linux (WSL) if is not fou
 export RUN_NODE_FORCE_WSL=1
 ```
 
+#### Customize the node command
+
+You could use the `RUN_NODE_CMD` environment variable to use a different command that includes the node execution.
+
+Example:
+
+```sh
+export RUN_NODE_CMD="meteor node"
+```
+
 ## Created by
 
 - [Sindre Sorhus](https://github.com/sindresorhus)

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,14 @@ export RUN_NODE_CACHE_PATH="/home/username/.node_path"
 ```
 
 
+#### WSL
+
+By default, node is run from the Windows Subsystem for Linux (WSL) if is not found in the main environment. You could prioritize the WSL usage by setting the `RUN_NODE_FORCE_WSL` environment variable.
+
+```sh
+export RUN_NODE_FORCE_WSL=1
+```
+
 ## Created by
 
 - [Sindre Sorhus](https://github.com/sindresorhus)

--- a/run-node
+++ b/run-node
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 # MIT License © Sindre Sorhus
 
+nodeParams="$@"
+versionNumberRegex="([0-9]{1,}\.)+[0-9]{1,}"
+nodeCmd="node"
+nodeCmdWithParams="${nodeCmd} ${nodeParams}"
+nodeVersionCmd="${nodeCmd} --version 2>/dev/null"
+
 if [[ -z $RUN_NODE_CACHE_PATH ]]; then
 	PATH_CACHE="$HOME"/.node_path
 else
@@ -27,6 +33,19 @@ has_node() {
 	command -v node >/dev/null 2>&1
 }
 
+has_wsl_node() {
+	[[ -f /c/Windows/System32/bash.exe ]] &&
+		echo $(/c/Windows/System32/bash.exe -c "${nodeVersionCmd}") | egrep -icq "${versionNumberRegex}"
+}
+
+run_node() {
+  eval "${nodeCmdWithParams}"
+}
+
+run_wsl_node() {
+	/c/Windows/System32/bash.exe -c "${nodeCmdWithParams}"
+}
+
 # Check if we have node, otherwise inherit path from user shell
 if ! has_node; then
 	set_path
@@ -38,12 +57,19 @@ if ! has_node; then
 	fi
 fi
 
-if has_node; then
-	node "$@"
+
+if [[ ! -z $RUN_NODE_FORCE_WSL ]] && has_wsl_node; then
+	run_wsl_node
 else
-	if [[ -z $RUN_NODE_ERROR_MSG ]]; then
-		echo "Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
- 	else
- 		echo "$RUN_NODE_ERROR_MSG"
- 	fi
+	if has_node; then
+		run_node
+	elif [[ -z $RUN_NODE_FORCE_WSL ]] && has_wsl_node; then
+		run_wsl_node
+	else # elsif check wsl and node and run the bash.exe node command
+		if [[ -z $RUN_NODE_ERROR_MSG ]]; then
+			echo "Couldn't find the Node.js binary. Ensure you have Node.js installed. Open an issue on https://github.com/sindresorhus/run-node"
+		else
+			echo "$RUN_NODE_ERROR_MSG"
+		fi
+	fi
 fi

--- a/run-node
+++ b/run-node
@@ -5,7 +5,7 @@ nodeParams="$@"
 versionNumberRegex="([0-9]{1,}\.)+[0-9]{1,}"
 nodeCmd=${RUN_NODE_CMD-"node"}
 nodeCmdWithParams="${nodeCmd} ${nodeParams}"
-nodeVersionCmd="${nodeCmd} --version 2>/dev/null"
+nodeVersionCmd="${nodeCmd} --version"
 
 if [[ -z $RUN_NODE_CACHE_PATH ]]; then
 	PATH_CACHE="$HOME"/.node_path
@@ -30,16 +30,16 @@ set_path() {
 }
 
 has_node() {
-	command -v node >/dev/null 2>&1
+  [[ "$(exec ${nodeVersionCmd} 2>/dev/null | egrep -ic ${versionNumberRegex})" -ne "0" ]]
 }
 
 has_wsl_node() {
 	[[ -f /c/Windows/System32/bash.exe ]] &&
-		echo $(/c/Windows/System32/bash.exe -c "${nodeVersionCmd}") | egrep -icq "${versionNumberRegex}"
+		[[ "$(/c/Windows/System32/bash.exe -c "${nodeVersionCmd}" 2>/dev/null | egrep -ic ${versionNumberRegex})" -ne "0" ]]
 }
 
 run_node() {
-  eval "${nodeCmdWithParams}"
+  exec ${nodeCmdWithParams}
 }
 
 run_wsl_node() {
@@ -47,7 +47,7 @@ run_wsl_node() {
 }
 
 # Check if we have node, otherwise inherit path from user shell
-if ! has_node; then
+if ! has_node && ! has_wsl_node; then
 	set_path
 
 	# Retry by deleting old path cache

--- a/run-node
+++ b/run-node
@@ -3,7 +3,7 @@
 
 nodeParams="$@"
 versionNumberRegex="([0-9]{1,}\.)+[0-9]{1,}"
-nodeCmd="node"
+nodeCmd=${RUN_NODE_CMD-"node"}
 nodeCmdWithParams="${nodeCmd} ${nodeParams}"
 nodeVersionCmd="${nodeCmd} --version 2>/dev/null"
 


### PR DESCRIPTION
This PR supports to look for node within the WSL context, if exists. Besides, it includes a way to configure the node command to use by using an environment variable.

## Pending testing

- [x] Unix env + node installed

- [x] Unix env + node uninstalled

- [x] Unix env + custom cmd (`meteor node`) + meteor installed

- [x] Unix env + custom cmd (`meteor node`) + meteor uninstalled

- [x] Windows env + node installed

- [x] Windows env + node uninstalled

- [x] WSL env + node installed

- [x] WSL env + node uninstalled

- [x] WSL env + custom cmd (`meteor node`) + meteor installed

- [x] WSL env + custom cmd (`meteor node`) + meteor uninstalled